### PR TITLE
build: use confection instead of thinc

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@ on:
   push:
     paths-ignore:
       - "*.md"
-    branches:
-      - "main"
   pull_request:
     types: [opened, synchronize, reopened, edited]
     paths-ignore:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
       - "*.md"
+    branches:
+      - "main"
   pull_request:
     types: [opened, synchronize, reopened, edited]
     paths-ignore:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Our libraries
-thinc>=8.1.0,<8.2.0
+confection>=0.0.4,<0.1.0
 wasabi>=0.9.1,<1.2.0
 srsly>=2.4.3,<3.0.0
 catalogue>=2.0.6,<2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ project_urls =
 
 [options]
 install_requires =
-    thinc>=8.1.0,<8.2.0
+    confection>=0.0.4,<0.1.0
     wasabi>=0.9.1,<1.2.0
     srsly>=2.4.3,<3.0.0
     catalogue>=2.0.6,<2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ project_urls =
 [options]
 install_requires =
     confection>=0.0.4,<0.1.0
+    packaging>=20.0
     wasabi>=0.9.1,<1.2.0
     srsly>=2.4.3,<3.0.0
     catalogue>=2.0.6,<2.1.0

--- a/weasel/_util.py
+++ b/weasel/_util.py
@@ -13,7 +13,7 @@ import srsly
 import typer
 from click import NoSuchOption
 from click.parser import split_arg_string
-from thinc.api import Config, ConfigValidationError
+from confection import Config, ConfigValidationError
 from wasabi import msg
 
 from .schemas import ProjectConfigSchema, validate

--- a/weasel/tests/test_cli.py
+++ b/weasel/tests/test_cli.py
@@ -6,8 +6,13 @@ import time
 import pytest
 import srsly
 
-from weasel._util import ConfigValidationError, is_subpath_of, load_project_config
-from weasel._util import substitute_project_variables, validate_project_commands
+from weasel._util import (
+    ConfigValidationError,
+    is_subpath_of,
+    load_project_config,
+    substitute_project_variables,
+    validate_project_commands,
+)
 from weasel.cli.remote_storage import RemoteStorage
 from weasel.cli.run import _check_requirements
 from weasel.schemas import ProjectConfigSchema, validate
@@ -241,7 +246,7 @@ def test_local_remote_storage_pull_missing():
 
             # comment
 
-            thinc""",
+            confection""",
             (False, False),
         ],
         [

--- a/weasel/tests/test_cli.py
+++ b/weasel/tests/test_cli.py
@@ -6,13 +6,8 @@ import time
 import pytest
 import srsly
 
-from weasel._util import (
-    ConfigValidationError,
-    is_subpath_of,
-    load_project_config,
-    substitute_project_variables,
-    validate_project_commands,
-)
+from weasel._util import ConfigValidationError, is_subpath_of, load_project_config
+from weasel._util import substitute_project_variables, validate_project_commands
 from weasel.cli.remote_storage import RemoteStorage
 from weasel.cli.run import _check_requirements
 from weasel.schemas import ProjectConfigSchema, validate


### PR DESCRIPTION
This PR removes `thinc` from the dependencies, replacing it with `confection`.