### PR TITLE
ci: remove redundant checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@ on:
   push:
     paths-ignore:
       - "*.md"
-    branches:
-      - "main"
   pull_request:
     types: [opened, synchronize, reopened, edited]
     paths-ignore:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths-ignore:
       - "*.md"
+    branches:
+      - "main"
+      - "release/*"
   pull_request:
     types: [opened, synchronize, reopened, edited]
     paths-ignore:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
       - "*.md"
+    branches:
+      - "main"
   pull_request:
     types: [opened, synchronize, reopened, edited]
     paths-ignore:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
       - "main"
       - "release/*"
   pull_request:
-    types: [opened, synchronize, reopened, edited]
     paths-ignore:
       - "*.md"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,12 +77,6 @@ jobs:
           python -m pip install -U -r requirements.txt
           python -m build --sdist
 
-      - name: Run mypy
-        shell: bash
-        if: env.RUN_MYPY == 'true' && matrix.python_version != '3.6'
-        run: |
-          python -m mypy $MODULE_NAME
-
       - name: Delete source directory
         shell: bash
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   validate:
     name: Validate
+    if: github.repository_owner == 'explosion'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,8 @@ on:
   push:
     paths-ignore:
       - "*.md"
-    branches:
-      - "main"
-      - "release/*"
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     paths-ignore:
       - "*.md"
 


### PR DESCRIPTION
This PR modifies the workflow to:

- remove checks for push events, unless they are on the `main` branch
- remove the `mypy` test step, since it's handled by the validation stage