### PR TITLE
Fix mypy pre-commit run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.0.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         additional_dependencies:
           - "types-requests"
           - "types-setuptools"
-          - "pydantic"
+          - "pydantic==1.10.10"
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/weasel/tests/cli/test_cli_app.py
+++ b/weasel/tests/cli/test_cli_app.py
@@ -100,7 +100,7 @@ def test_project_assets(project_dir: Path):
 
 
 def test_project_run(project_dir: Path):
-    # make sure dry run works
+    # make sure dry run works correctly
     test_file = project_dir / "abc.txt"
     result = CliRunner().invoke(app, ["run", "--dry", "create", str(project_dir)])
     assert result.exit_code == 0

--- a/weasel/tests/cli/test_cli_app.py
+++ b/weasel/tests/cli/test_cli_app.py
@@ -100,7 +100,7 @@ def test_project_assets(project_dir: Path):
 
 
 def test_project_run(project_dir: Path):
-    # make sure dry run works correctly
+    # make sure dry run works
     test_file = project_dir / "abc.txt"
     result = CliRunner().invoke(app, ["run", "--dry", "create", str(project_dir)])
     assert result.exit_code == 0


### PR DESCRIPTION
## Description

The pre-commit hook didn't have a pin for Pydantic, causing it to pull in the latest v2.
Also, the `mypy` pin was outside of the range specified in `requirements.txt`.

I'd leave this PR as-is to fix the current CI failure, and perhaps in the future pin all dependencies in the pre-commit configuration to avoid further unexpected surprises.

### Types of change

CI bug fix

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the test suite, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
