### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,11 +53,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        include:
-          - os: ubuntu-20.04
-            python_version: "3.6"
-          - os: windows-2019
-            python_version: "3.6"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ pytest>=5.2.0,!=7.1.0
 mypy>=1.5.0,<1.7.0; python_version >= "3.8"
 types-requests
 types-setuptools>=57.0.0
-ruff>=0.0.259; python_version > "3.6"
+ruff>=0.0.259
 isort>=5.12.0,<6.0; python_version > "3.7"
 pre-commit>=3.2.0,<4.0.0; python_version > "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -30,7 +29,7 @@ project_urls =
     Source = https://github.com/explosion/weasel/
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     confection>=0.0.4,<0.2.0
     packaging>=20.0


### PR DESCRIPTION

## Description

Drop support for Python 3.6, as we did in spaCy v3.7.0.

### Types of change

update

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the test suite, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
