### PR TITLE
Fix: Replace outdated command name "project" with "weasel"

### DIFF
--- a/weasel/cli/run.py
+++ b/weasel/cli/run.py
@@ -98,7 +98,7 @@ def project_run(
         for dep in cmd.get("deps", []):
             if not (project_dir / dep).exists():
                 err = f"Missing dependency specified by command '{subcommand}': {dep}"
-                err_help = "Maybe you forgot to run the 'project assets' command or a previous step?"
+                err_help = "Maybe you forgot to run the 'weasel assets' command or a previous step?"
                 err_exits = 1 if not dry else None
                 msg.fail(err, err_help, exits=err_exits)
         check_spacy_env_vars()


### PR DESCRIPTION
Hello Explosion team,

---

<!--- Provide a general summary of your changes in the title. -->
I suggest the replacement of the outdated command name in a hint message.

## Description

In a hint message, when running a command with unmet dependencies, the `weasel assets` command was still referenced as `project assets` (from the time when `weasel` was still included in _spaCy_ as `spacy project` command).

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

The command name `project` is updated within the hint to reflect the current command name `weasel`.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the test suite, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

---

Best regards
Martin
